### PR TITLE
fix: remove unused `numpy` import

### DIFF
--- a/examples/all_supported_blocks.py
+++ b/examples/all_supported_blocks.py
@@ -1,5 +1,4 @@
 from math import floor, ceil
-from numpy import broadcast
 from boiga import *
 
 project = Project()


### PR DESCRIPTION
This was probably from VS Code's intellisense automatically importing it for you.